### PR TITLE
Add Package Version to API details

### DIFF
--- a/src/apisof.net/Shared/ApiDetails.razor
+++ b/src/apisof.net/Shared/ApiDetails.razor
@@ -346,7 +346,7 @@
                     <tr>
                         <th>Package</th>
                         <td>
-                            <a href="https://nuget.org/packages/@package.Name">@package.Name</a> <span class="small text-muted">@folder</span>
+                            <a href="https://nuget.org/packages/@package.Name/@package.Version">@package.Name (@package.Version)</a> <span class="small text-muted">@folder</span>
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
@terrajobst: @tarekgh and I were looking at apisof.net and he had a good suggestion to include the package version in the API  details.  We decided to give it a try and found it was available.  Does this look OK?  Any way for us to test this locally?