### PR TITLE
Accessibility: Ensure img elements have alternative text or a role of none or presentation

### DIFF
--- a/src/apisof.net/Shared/Glyph.razor
+++ b/src/apisof.net/Shared/Glyph.razor
@@ -1,3 +1,3 @@
 @using ApisOfDotNet.Services
 
-<img height="16" width="16" src="@Url" alt="" role="presentation" />
+<img height="16" width="16" src="@Url" role="presentation" />


### PR DESCRIPTION
Fixes accessibility issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2395629

before:
<img width="1917" height="925" alt="image" src="https://github.com/user-attachments/assets/f05c32fd-bde4-44b0-8ca5-b8eb639e0c4b" />

after:
<img width="1917" height="972" alt="image" src="https://github.com/user-attachments/assets/70ae5c8c-99f2-412c-b857-7f192d4e89cb" />

