### PR TITLE
Workaround for CI pipeline failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - name: Get code


### PR DESCRIPTION
The `UsageDatabase_CloseOpen_ReleasesAndReacquiresFileLock` test case fails on Linux but passes on Windows.