### PR TITLE
Accessibility: When we use the TAB key to navigate after the ".Net Upgrade Planner" button, the keyboard focus shifts to hidden content

### DIFF
--- a/src/apisof.net/Shared/MainLayout.razor
+++ b/src/apisof.net/Shared/MainLayout.razor
@@ -53,7 +53,7 @@
     </div>
 </nav>
 
-<div class="nofocus" tabindex="0">
+<div class="nofocus">
     <CascadingValue Value="this">
     @Body
     </CascadingValue>


### PR DESCRIPTION
Fixes accessibility issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2395652