### PR TITLE
Accessibility: Users are not able to differentiate between links and the surrounding text

### DIFF
--- a/src/apisof.net/Pages/CatalogRoot.razor
+++ b/src/apisof.net/Pages/CatalogRoot.razor
@@ -36,7 +36,7 @@
                         var childCssClasses = childData?.CssClasses ?? string.Empty;
                         var childMarkup = childData?.AdditionalMarkup;
                         <li>
-                            <Glyph Kind="@child.Kind.GetGlyph()"/> <a class="@childCssClasses" href="@Link.For(child)">@child.Name</a> @childMarkup
+                            <Glyph Kind="@child.Kind.GetGlyph()" /> <a class="@childCssClasses" href="@Link.For(child)">@child.Name  <span class="oi oi-link-intact ml-1 small" aria-hidden="true"></span></a> @childMarkup
                         </li>
                     }
                 </ItemLimiter>


### PR DESCRIPTION
Fixes accessibility issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2397304

After discussing with the bug creator, add a link icon next to the link text to differentiate between links and the surrounding text.

<img width="543" height="389" alt="image" src="https://github.com/user-attachments/assets/45d54189-0280-4962-a4ec-0db2643575ef" />
<img width="546" height="505" alt="image" src="https://github.com/user-attachments/assets/cb606f98-f147-4e6d-9948-a010adb60abc" />
