### PR TITLE
Color contrast ratio of focus border over "Show 3482 remaining items" button is less than 3:1

### DIFF
--- a/src/apisof.net/wwwroot/css/site.css
+++ b/src/apisof.net/wwwroot/css/site.css
@@ -553,3 +553,25 @@ a, a:link, a:visited
 .navbar-nav .nav-link:hover {
     color: #F0F0F0 !important;
 }
+
+input:not([type="checkbox"]):not([type="radio"]),
+select,
+textarea
+{
+    border-color: #1D72CC !important;
+}
+
+    input:not([type="checkbox"]):not([type="radio"]):focus,
+    select:focus,
+    textarea:focus
+    {
+        border-color: #1D72CC !important;
+        box-shadow: 0 0 0 0.2rem rgba(29, 114, 204, 0.25) !important;
+        outline: none !important;
+    }
+
+.btn:focus
+{
+    border-color: #09102A !important;
+    outline: none !important;
+}


### PR DESCRIPTION
Fixes accessibility bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2395646

Fixed the border contrast issues for button, input, and select elements on three previously missed pages.

