### PR TITLE
Fixed the issue where fx-version overlapped with code

### DIFF
--- a/src/apisof.net/wwwroot/css/site.css
+++ b/src/apisof.net/wwwroot/css/site.css
@@ -220,8 +220,9 @@ a, a:link, a:visited
 .syntax-view .fx-version.fx-version-inbox,
 .syntax-view .fx-version.fx-version-package {
     position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
+    border-radius: 0.25rem;
+    top: 0;
+    right: 0;
 }
 
 .syntax-view.diff-added, .syntax-view .diff-added {
@@ -234,6 +235,7 @@ a, a:link, a:visited
 
 .syntax-view pre {
     margin-bottom: 0;
+    margin-top: 0.5rem;
     color: black;
 }
 


### PR DESCRIPTION
Contribute to bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2397296

Fixed the issue where fx-version overlapped with code

before: 
<img width="638" height="427" alt="image" src="https://github.com/user-attachments/assets/b9218dc3-0ead-4fef-afbf-a163325e38d6" />
after: 
<img width="629" height="495" alt="image" src="https://github.com/user-attachments/assets/34dc29f2-b081-46b7-a36b-84d557357fe9" />
