### PR TITLE
Update NuGet package sources in nuget.config

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnetlegacy@Local" value="https://devdiv.pkgs.visualstudio.com/OnlineServices/_packaging/dotnetlegacy%40Local/nuget/v3/index.json" />
+    <add key="dotnetlegacy" value="https://devdiv.pkgs.visualstudio.com/OnlineServices/_packaging/dotnetlegacy/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Replaces existing package sources with a single 'dotnetlegacy@Local' source and removes package source mapping. This simplifies the configuration and changes the source of NuGet packages for the project.