### PR TITLE
Add xunit.extensibility.execution to test projects

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,7 +40,8 @@
     <PackageVersion Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.4.2-pre.22" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.2-pre.22" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup Label="Transitive Updates">

--- a/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
+++ b/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
@@ -18,11 +18,12 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
@@ -20,11 +20,12 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
@@ -23,11 +23,12 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Added the xunit.extensibility.execution package (version 2.4.2-pre.22) to all test projects and updated the xunit package version to match. This ensures compatibility with the latest xUnit extensibility features.