### PR TITLE
Update xunit packages and configure NuGet source mapping

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,9 +40,8 @@
     <PackageVersion Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.4.2-pre.22" />
-    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.2-pre.22" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
   <ItemGroup Label="Transitive Updates">
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />

--- a/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
+++ b/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
@@ -18,12 +18,11 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit" />
+        <Using Include="Xunit"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
@@ -20,12 +20,11 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit" />
+        <Using Include="Xunit"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
@@ -23,12 +23,11 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit" />
+        <Using Include="Xunit"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -4,4 +4,10 @@
     <clear />
     <add key="dotnetlegacy" value="https://devdiv.pkgs.visualstudio.com/OnlineServices/_packaging/dotnetlegacy/nuget/v3/index.json" />
   </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="dotnetlegacy">
+      <package pattern="Microsoft.Cci.Extensions" />
+    </packageSource> 
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Upgraded xunit and xunit.runner.visualstudio package versions and removed xunit.extensibility.execution from test projects. Added package source mapping for Microsoft.Cci.Extensions in nuget.config to ensure correct package source usage.