### PR TITLE
Update xUnit packages and clean up NuGet config

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,8 +40,10 @@
     <PackageVersion Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit" Version="2.4.2-pre.22" />
+    <PackageVersion Include="xunit.analyzers" Version="0.12.0-pre.20" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.2-pre.22" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup Label="Transitive Updates">
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />

--- a/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
+++ b/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
@@ -18,11 +18,12 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
@@ -20,11 +20,12 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
@@ -23,11 +23,12 @@
         <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.extensibility.execution" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -4,10 +4,4 @@
     <clear />
     <add key="dotnetlegacy" value="https://devdiv.pkgs.visualstudio.com/OnlineServices/_packaging/dotnetlegacy/nuget/v3/index.json" />
   </packageSources>
-
-  <packageSourceMapping>
-    <packageSource key="dotnetlegacy">
-      <package pattern="Microsoft.Cci.Extensions" />
-    </packageSource> 
-  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Upgraded xUnit and related packages to pre-release 2.4.2 versions and added xunit.analyzers and xunit.extensibility.execution. Also removed unused packageSourceMapping for Microsoft.Cci.Extensions from nuget.config.