### PR TITLE
Update xunit packages and remove unused test dependencies

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -7,7 +7,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,10 +40,8 @@
     <PackageVersion Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.4.2-pre.22" />
-    <PackageVersion Include="xunit.analyzers" Version="0.12.0-pre.20" />
-    <PackageVersion Include="xunit.extensibility.execution" Version="2.4.2-pre.22" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
   <ItemGroup Label="Transitive Updates">
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />

--- a/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
+++ b/src/Terrajobst.ApiCatalog.Tests/Terrajobst.ApiCatalog.Tests.csproj
@@ -15,10 +15,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.extensibility.execution" />
+        <PackageReference Include="xunit" /> 
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Storage.Tests/Terrajobst.UsageCrawling.Storage.Tests.csproj
@@ -17,10 +17,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.extensibility.execution" />
+        <PackageReference Include="xunit" /> 
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
+++ b/src/Terrajobst.UsageCrawling.Tests/Terrajobst.UsageCrawling.Tests.csproj
@@ -20,10 +20,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.extensibility.execution" />
+        <PackageReference Include="xunit" /> 
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Upgraded xunit and xunit.runner.visualstudio to newer versions in Directory.Packages.props. Removed Meziantou.Xunit.ParallelTestFramework and xunit.extensibility.execution from test project files and build targets to clean up unused dependencies.