### PR TITLE
Update xunit and runner to version 2.4.2

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,8 +40,8 @@
     <PackageVersion Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Toolbelt.Blazor.HotKeys2" Version="5.1.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit" Version="2.4.2-pre.22" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup Label="Transitive Updates">
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />


### PR DESCRIPTION
Bump xunit to 2.4.2-pre.22 and xunit.runner.visualstudio to 2.4.2 in Directory.Packages.props for improved compatibility and stability.