### PR TITLE
Switch NuGet source to nuget.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -432,7 +432,6 @@ $RECYCLE.BIN/
 !.vscode/launch.json
 !.vscode/extensions.json
 
-
 ##
 ## lscache
 ##

--- a/.gitignore
+++ b/.gitignore
@@ -431,3 +431,9 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+
+##
+## lscache
+##
+*.lscache

--- a/pipelines/build-pipeline.yml
+++ b/pipelines/build-pipeline.yml
@@ -56,8 +56,6 @@ extends:
                 inputs:
                   version: 8.x
                   includePreviewVersions: true
-              - task: NuGetAuthenticate@1
-                displayName: "NuGet Authenticate"
               - script: |
                   cd src/apisof.net
                   dotnet clean

--- a/pipelines/build-telemetry.yml
+++ b/pipelines/build-telemetry.yml
@@ -48,8 +48,6 @@ extends:
                 displayName: Use .NET 8 SDK
                 inputs:
                   version: 8.x
-              - task: NuGetAuthenticate@1
-                displayName: "NuGet Authenticate"
               - script: |
                   dotnet publish src/NetUpgradePlannerTelemetry/NetUpgradePlannerTelemetry.csproj -o "$(Build.ArtifactStagingDirectory)/publish" /p:SourceRevisionId=$(Build.SourceVersion)
                 displayName: Publish Function

--- a/pipelines/gen-design-notes.yml
+++ b/pipelines/gen-design-notes.yml
@@ -48,8 +48,6 @@ extends:
                 displayName: Use .NET 8 SDK
                 inputs:
                   version: 8.x
-              - task: NuGetAuthenticate@1
-                displayName: "NuGet Authenticate"
               - task: AzureCLI@2
                 displayName: "Run GenDesignNotes"
                 inputs:

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnetlegacy" value="https://devdiv.pkgs.visualstudio.com/OnlineServices/_packaging/dotnetlegacy/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Replace the internal 'dotnetlegacy' package source with the public nuget.org feed in src/nuget.config by updating the package source key and URL to https://api.nuget.org/v3/index.json so packages resolve from the official NuGet registry.