### PR TITLE
Add NuGetAuthenticate step to build pipeline

### DIFF
--- a/pipelines/build-pipeline.yml
+++ b/pipelines/build-pipeline.yml
@@ -51,6 +51,8 @@ extends:
                   artifactName: apis-of-dotnet-drop
             steps:
               - checkout: self
+              - task: NuGetAuthenticate@1
+                displayName: "Authenticate with NuGet feeds"
               - task: UseDotNet@2
                 displayName: Use .NET 8 SDK
                 inputs:


### PR DESCRIPTION
Insert NuGetAuthenticate@1 into pipelines/build-pipeline.yml (after checkout) to authenticate with NuGet feeds before the build. This ensures the pipeline can restore packages from private/secured feeds during the CI process.