### PR TITLE
Fix vpk pack duplicate

### DIFF
--- a/pipelines/templates/steps-build-planner.yml
+++ b/pipelines/templates/steps-build-planner.yml
@@ -15,11 +15,11 @@ steps:
       # Use Build.BuildId for versioning to ensure monotonically increasing versions
       $buildId = "$(Build.BuildId)"
       $gitHash = "$(Build.SourceVersion)".Substring(0, 10)
-      $version = "0.1.$buildId-beta+$gitHash"
+      $version = "0.1.$buildId+$gitHash"
 
       Write-Host "Computed Version: $version"
       
-      Write-Host "##vso[task.setvariable variable=NBGV_SemVer1]$version"
+      Write-Host "##vso[task.setvariable variable=PlannerSemVer]$version"
     displayName: "Set build version (using Build.BuildId)"
   - pwsh: |
       $ErrorActionPreference = 'Stop'
@@ -30,7 +30,7 @@ steps:
     displayName: "dotnet publish"
   - pwsh: |
       $ErrorActionPreference = 'Stop'
-      $version = $env:NBGV_SemVer1
+      $version = $env:PlannerSemVer
 
       if ([string]::IsNullOrWhiteSpace($version)) {
         throw "Build version is empty. Ensure the 'Set build version' step executed successfully."
@@ -46,4 +46,4 @@ steps:
       Copy-Item -Path "$(Build.SourcesDirectory)/src/nuget.config" -Destination (Join-Path $inputRoot "nuget.config") -Force
     displayName: "Prepare velopack inputs"
     env:
-      NBGV_SemVer1: $(NBGV_SemVer1)
+      PlannerSemVer: $(PlannerSemVer)

--- a/pipelines/templates/steps-build-planner.yml
+++ b/pipelines/templates/steps-build-planner.yml
@@ -11,13 +11,16 @@ steps:
       version: 8.x
   - pwsh: |
       $ErrorActionPreference = 'Stop'
-      $config = "$(Build.SourcesDirectory)/src/nuget.config"
-      dotnet tool update -g nbgv --configfile $config
-      if ($LASTEXITCODE -ne 0) {
-        dotnet tool install -g nbgv --configfile $config
-      }
-      nbgv cloud -p ${{ parameters.projectPath }} -a
-    displayName: "Set build version (nbgv)"
+      
+      # Use Build.BuildId for versioning to ensure monotonically increasing versions
+      $buildId = "$(Build.BuildId)"
+      $gitHash = "$(Build.SourceVersion)".Substring(0, 10)
+      $version = "0.1.$buildId-beta+$gitHash"
+
+      Write-Host "Computed Version: $version"
+      
+      Write-Host "##vso[task.setvariable variable=NBGV_SemVer1]$version"
+    displayName: "Set build version (using Build.BuildId)"
   - pwsh: |
       $ErrorActionPreference = 'Stop'
       $publishDest = "$(Build.ArtifactStagingDirectory)/velopack-input/publish/NetUpgradePlanner"
@@ -27,14 +30,14 @@ steps:
     displayName: "dotnet publish"
   - pwsh: |
       $ErrorActionPreference = 'Stop'
-      $version = $env:PLANNER_SEMVER1
+      $version = $env:NBGV_SemVer1
 
       if ([string]::IsNullOrWhiteSpace($version)) {
-        throw "NBGV version variable is missing. Ensure 'nbgv cloud -p ${{ parameters.projectPath }} -a' completed successfully."
+        throw "Build version is empty. Ensure the 'Set build version' step executed successfully."
       }
 
       if ($version -match '^\$\(') {
-        throw "NBGV version variable was not expanded (got literal '$version'). Ensure 'nbgv cloud -p ${{ parameters.projectPath }} -a' ran with the -a/--all-vars flag so NBGV_SemVer1 is published."
+        throw "Build version was not expanded (got literal '$version'). Ensure pipeline variables are properly set."
       }
 
       $inputRoot = "$(Build.ArtifactStagingDirectory)/velopack-input"
@@ -43,4 +46,4 @@ steps:
       Copy-Item -Path "$(Build.SourcesDirectory)/src/nuget.config" -Destination (Join-Path $inputRoot "nuget.config") -Force
     displayName: "Prepare velopack inputs"
     env:
-      PLANNER_SEMVER1: $(NBGV_SemVer1)
+      NBGV_SemVer1: $(NBGV_SemVer1)

--- a/pipelines/templates/upload-build-planner.yml
+++ b/pipelines/templates/upload-build-planner.yml
@@ -60,7 +60,7 @@ steps:
       }
       else {
         Write-Host "Attempting to package version $version..."
-        if($LASTEXITCODE -ne 0) {
+        if (-not (Get-Command vpk -ErrorAction SilentlyContinue)) {
           throw "vpk tool is not available. Ensure it is installed and in the PATH."
         }
         try {

--- a/pipelines/templates/upload-build-planner.yml
+++ b/pipelines/templates/upload-build-planner.yml
@@ -59,8 +59,21 @@ steps:
         Write-Host "##vso[task.setvariable variable=PlannerVersion]$version"
       }
       else {
-        vpk pack --packId "NetUpgradePlanner" --packTitle ".NET Upgrade Planner" --packVersion "$version" --packAuthors "Immo Landwerth" --packDir "." --framework net8-x64-desktop --mainExe NetUpgradePlanner.exe --outputDir "$releaseDir"
-        Write-Host "##vso[task.setvariable variable=PlannerVersionExists]false"
+        Write-Host "Attempting to package version $version..."
+        try {
+          vpk pack --packId "NetUpgradePlanner" --packTitle ".NET Upgrade Planner" --packVersion "$version" --packAuthors "Immo Landwerth" --packDir "." --framework net8-x64-desktop --mainExe NetUpgradePlanner.exe --outputDir "$releaseDir"
+          Write-Host "Successfully packaged version $version"
+          Write-Host "##vso[task.setvariable variable=PlannerVersionExists]false"
+        }
+        catch {
+          if ($_ -match "equal or greater" -or $_ -match "409") {
+            Write-Host "Version $version already exists in release channel; skipping to avoid conflict."
+            Write-Host "##vso[task.setvariable variable=PlannerVersionExists]true"
+          }
+          else {
+            throw $_
+          }
+        }
         Write-Host "##vso[task.setvariable variable=PlannerVersion]$version"
       }
     displayName: "vpk pack"

--- a/pipelines/templates/upload-build-planner.yml
+++ b/pipelines/templates/upload-build-planner.yml
@@ -60,8 +60,15 @@ steps:
       }
       else {
         Write-Host "Attempting to package version $version..."
+        if($LASTEXITCODE -ne 0) {
+          throw "vpk tool is not available. Ensure it is installed and in the PATH."
+        }
         try {
           vpk pack --packId "NetUpgradePlanner" --packTitle ".NET Upgrade Planner" --packVersion "$version" --packAuthors "Immo Landwerth" --packDir "." --framework net8-x64-desktop --mainExe NetUpgradePlanner.exe --outputDir "$releaseDir"
+          if ($LASTEXITCODE -ne 0) {
+            throw "vpk pack failed with exit code $LASTEXITCODE."
+          }
+
           Write-Host "Successfully packaged version $version"
           Write-Host "##vso[task.setvariable variable=PlannerVersionExists]false"
         }


### PR DESCRIPTION
This pull request updates the build and packaging pipeline for the .NET Upgrade Planner to simplify versioning and improve reliability. The most significant change is the removal of the dependency on the `nbgv` tool for versioning, replacing it with a versioning scheme based on the Azure DevOps `Build.BuildId` and Git commit hash. Additional improvements include better error handling in the packaging step and updates to environment variable usage.

**Build versioning improvements:**

* Replaced the use of the `nbgv` tool for versioning with a custom version string that uses `Build.BuildId` and a shortened Git commit hash, ensuring monotonically increasing and unique versions. (`pipelines/templates/steps-build-planner.yml`)
* Updated all references from the previous `PLANNER_SEMVER1` environment variable to the new `NBGV_SemVer1` variable, aligning with the new versioning approach. (`pipelines/templates/steps-build-planner.yml`) [[1]](diffhunk://#diff-f30434f7169dca7781da8704b260a2fcf0e2baa41b4df5c0dedbcba06a297602L30-R40) [[2]](diffhunk://#diff-f30434f7169dca7781da8704b260a2fcf0e2baa41b4df5c0dedbcba06a297602L46-R49)

**Packaging and error handling:**

* Enhanced the error handling in the `vpk pack` step to gracefully handle cases where the package version already exists, avoiding unnecessary failures and providing clearer log messages. (`pipelines/templates/upload-build-planner.yml`)