### PR TITLE
Catalog diff feature is broken

### DIFF
--- a/src/Terrajobst.ApiCatalog/CatalogModel/ApiAvailabilityContext.cs
+++ b/src/Terrajobst.ApiCatalog/CatalogModel/ApiAvailabilityContext.cs
@@ -133,7 +133,9 @@ internal sealed class ApiAvailabilityContext
 
         foreach (var declaration in api.Declarations)
         {
-            var assemblyId = declaration.Assembly.Id;
+            if (!TryGetAssemblyId(declaration, out var assemblyId))
+                continue;
+
             if (frameworkAssemblies.Contains(assemblyId) || packageAssemblies.ContainsKey(assemblyId))
                 return true;
         }
@@ -151,7 +153,9 @@ internal sealed class ApiAvailabilityContext
 
         foreach (var declaration in api.Declarations)
         {
-            var assemblyId = declaration.Assembly.Id;
+            if (!TryGetAssemblyId(declaration, out var assemblyId))
+                continue;
+
             if (frameworkAssemblies.Contains(assemblyId))
                 return declaration;
         }
@@ -198,13 +202,16 @@ internal sealed class ApiAvailabilityContext
 
         foreach (var declaration in api.Declarations)
         {
-            if (frameworkAssemblies.Contains(declaration.Assembly.Id))
+            if (!TryGetAssemblyId(declaration, out var assemblyId))
+                continue;
+
+            if (frameworkAssemblies.Contains(assemblyId))
             {
                 frameworkBuilder ??= ImmutableArray.CreateBuilder<ApiDeclarationModel>();
                 frameworkBuilder.Add(declaration);
             }
 
-            if (packageAssemblies.TryGetValue(declaration.Assembly.Id, out var packageInfo))
+            if (packageAssemblies.TryGetValue(assemblyId, out var packageInfo))
             {
                 packageBuilder ??= ImmutableArray.CreateBuilder<(PackageModel, NuGetFramework, ApiDeclarationModel)>();
 
@@ -233,6 +240,20 @@ internal sealed class ApiAvailabilityContext
             return (string.Empty, ImmutableArray<string>.Empty);
 
         return info;
+    }
+
+    private static bool TryGetAssemblyId(ApiDeclarationModel declaration, out int assemblyId)
+    {
+        try
+        {
+            assemblyId = declaration.Assembly.Id;
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            assemblyId = default;
+            return false;
+        }
     }
 
     private sealed class PackageFolder : IFrameworkSpecific


### PR DESCRIPTION
This pull request improves the robustness of API availability checks in `ApiAvailabilityContext.cs` by safely handling cases where accessing an assembly ID might throw an exception. The main change introduces a helper method to safely retrieve the assembly ID, preventing runtime errors and making the code more resilient.

**Error handling improvements:**

* Added a new private static method `TryGetAssemblyId` to safely attempt retrieving the `Assembly.Id` from an `ApiDeclarationModel`, catching any `ArgumentOutOfRangeException` and returning a boolean to indicate success.
* Updated all usages of `declaration.Assembly.Id` in the `IsAvailable` and `GetAvailability` methods to use `TryGetAssemblyId`, skipping any declarations where the assembly ID cannot be safely retrieved. [[1]](diffhunk://#diff-e2ddc5af483dae2b76c78fd6677f793c05afd6db5f7d0ca36407233cbb8fd42bL136-R138) [[2]](diffhunk://#diff-e2ddc5af483dae2b76c78fd6677f793c05afd6db5f7d0ca36407233cbb8fd42bL154-R158) [[3]](diffhunk://#diff-e2ddc5af483dae2b76c78fd6677f793c05afd6db5f7d0ca36407233cbb8fd42bL201-R214)

These changes help prevent potential crashes due to out-of-range exceptions when accessing assembly IDs in API declarations.