### PR TITLE
Adjust release pipeline schedules

### DIFF
--- a/pipelines/release-gen-catalog-pipeline.yml
+++ b/pipelines/release-gen-catalog-pipeline.yml
@@ -1,8 +1,8 @@
 trigger: none
 
 schedules:
-  - cron: "21 12 * * *" # 12:21 PM UTC
-    displayName: Daily 12:21 UTC
+  - cron: "00 00 * * *" # 12:00 AM UTC
+    displayName: Daily 12:00 AM UTC
     branches:
       include:
         - main

--- a/pipelines/release-gen-usage-pipeline.yml
+++ b/pipelines/release-gen-usage-pipeline.yml
@@ -3,8 +3,8 @@ trigger: none
 name: $(Date:yyyyMMdd).$(Rev:r)
 
 schedules:
-  - cron: "21 */6 * * *" # At :21 in every 6th hour
-    displayName: "Release usage every 6 hours"
+  - cron: "00 09,21 * * *" # At 09:00 and 21:00 UTC daily (avoids 00:00-08:00 catalog window)
+    displayName: "Release usage every 12 hours (09:00/21:00 UTC)"
     branches:
       include:
         - main


### PR DESCRIPTION
Update release pipeline cron schedules for better timing coordination: run catalog generation daily at 00:00 UTC, and run usage generation at 09:00 and 21:00 UTC (every 12 hours) to avoid the 00:00–08:00 catalog window.